### PR TITLE
add closing tag for checkMK piggyback output

### DIFF
--- a/lib/PostgreSQL/SecureMonitoring/Output/CheckMK.pm
+++ b/lib/PostgreSQL/SecureMonitoring/Output/CheckMK.pm
@@ -358,7 +358,8 @@ sub for_each_host
    #<<< no pertidy formatting
    $self->add_output( "<<<<$host_result->{name}>>>>\n"
            .  "<<<posemo>>>\n"
-           .  $json->encode( $host_result ) . "\n" );
+           .  $json->encode( $host_result ) . "\n"
+           .  "<<<<>>>>\n" );
    #>>>
 
    return;


### PR DESCRIPTION
Hi Alvar, 
cloud you please add the missing closing tag for the (piggyback) data of other hosts (see comment in line 51). Unfortunately I'm not a perl programmer and the new line of code isn't tested yet. Could you please review it?
The output should have the structure as in line 48-51 described.

Thanks a lot and many greetings from munich
Tobi 